### PR TITLE
 re-add --marker option

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -7,6 +7,7 @@ import { PipeParser } from '../parsers/pipe.parser.js';
 import { DirectiveParser } from '../parsers/directive.parser.js';
 import { ServiceParser } from '../parsers/service.parser.js';
 import { MarkerParser } from '../parsers/marker.parser.js';
+import { FunctionParser } from '../parsers/function.parser.js';
 import { PostProcessorInterface } from '../post-processors/post-processor.interface.js';
 import { SortByKeyPostProcessor } from '../post-processors/sort-by-key.post-processor.js';
 import { KeyAsDefaultValuePostProcessor } from '../post-processors/key-as-default-value.post-processor.js';
@@ -79,6 +80,12 @@ export const cli: any = y // temporary any
 		describe: 'Remove obsolete strings after merge',
 		type: 'boolean'
 	})
+	.option('marker', {
+		alias: 'm',
+		describe: 'Name of a custom marker function for extracting strings',
+		type: 'string',
+		default: undefined
+	})
 	.option('key-as-default-value', {
 		alias: 'k',
 		describe: 'Use key as default value',
@@ -115,7 +122,12 @@ const extractTask = new ExtractTask(cli.input, cli.output, {
 });
 
 // Parsers
-const parsers: ParserInterface[] = [new PipeParser(), new DirectiveParser(), new ServiceParser(), new MarkerParser()];
+const parsers: ParserInterface[] = [new PipeParser(), new DirectiveParser(), new ServiceParser()];
+if (cli.marker) {
+	parsers.push(new FunctionParser(cli.marker))
+} else {
+	parsers.push(new MarkerParser())
+}
 extractTask.setParsers(parsers);
 
 // Post processors

--- a/src/parsers/function.parser.ts
+++ b/src/parsers/function.parser.ts
@@ -1,0 +1,33 @@
+import { tsquery } from '@phenomnomnominal/tsquery';
+
+import { ParserInterface } from './parser.interface.js';
+import { TranslationCollection } from '../utils/translation.collection.js';
+import { getStringsFromExpression, findSimpleCallExpressions } from '../utils/ast-helpers.js';
+import pkg from 'typescript';
+const { isIdentifier } = pkg;
+
+export class FunctionParser implements ParserInterface {
+	constructor(private fnName: string) {}
+
+	public extract(source: string, filePath: string): TranslationCollection | null {
+		const sourceFile = tsquery.ast(source, filePath);
+
+		let collection: TranslationCollection = new TranslationCollection();
+
+		const callExpressions = findSimpleCallExpressions(sourceFile, this.fnName);
+		callExpressions.forEach((callExpression) => {
+			if (!isIdentifier(callExpression.expression)
+			    || callExpression.expression.escapedText != this.fnName) {
+				return
+			}
+
+			const [firstArg] = callExpression.arguments;
+			if (!firstArg) {
+				return;
+			}
+			const strings = getStringsFromExpression(firstArg);
+			collection = collection.addKeys(strings);
+		});
+		return collection;
+	}
+}

--- a/src/utils/ast-helpers.ts
+++ b/src/utils/ast-helpers.ts
@@ -83,6 +83,14 @@ export function findFunctionCallExpressions(node: Node, fnName: string | string[
 	return tsquery<CallExpression>(node, query);
 }
 
+export function findSimpleCallExpressions(node: Node, fnName: string) {
+	if (Array.isArray(fnName)) {
+		fnName = fnName.join('|');
+	}
+	const query = `CallExpression:has(Identifier[name="${fnName}"])`;
+	return tsquery<CallExpression>(node, query);
+}
+
 export function findPropertyCallExpressions(node: Node, prop: string, fnName: string | string[]): CallExpression[] {
 	if (Array.isArray(fnName)) {
 		fnName = fnName.join('|');

--- a/tests/parsers/function.parser.spec.ts
+++ b/tests/parsers/function.parser.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+
+import { FunctionParser } from '../../src/parsers/function.parser.js';
+
+describe('FunctionParser', () => {
+	const componentFilename: string = 'test.component.ts';
+
+	let parser: FunctionParser;
+
+	beforeEach(() => {
+		parser = new FunctionParser('MK');
+	});
+
+	it('should extract strings using marker function', () => {
+		const contents = `
+			MK('Hello world');
+			MK(['I', 'am', 'extracted']);
+			otherFunction('But I am not');
+			MK(message || 'binary expression');
+			MK(message ? message : 'conditional operator');
+			MK('FOO.bar');
+		`;
+		const keys = parser.extract(contents, componentFilename).keys();
+		expect(keys).to.deep.equal(['Hello world', 'I', 'am', 'extracted', 'binary expression', 'conditional operator', 'FOO.bar']);
+	});
+
+	it('should extract split strings', () => {
+		const contents = `
+			MK('Hello ' + 'world');
+			MK('This is a ' + 'very ' + 'very ' + 'very ' + 'very ' + 'long line.');
+			MK('Mix ' + \`of \` + 'different ' + \`types\`);
+		`;
+		const keys = parser.extract(contents, componentFilename).keys();
+		expect(keys).to.deep.equal(['Hello world', 'This is a very very very very long line.', 'Mix of different types']);
+	});
+
+	it('should extract split strings while keeping html tags', () => {
+		const contents = `
+			MK('Hello ' + 'world');
+			MK('This <em>is</em> a ' + 'very ' + 'very ' + 'very ' + 'very ' + 'long line.');
+			MK('Mix ' + \`of \` + 'different ' + \`types\`);
+		`;
+		const keys = parser.extract(contents, componentFilename).keys();
+		expect(keys).to.deep.equal(['Hello world', 'This <em>is</em> a very very very very long line.', 'Mix of different types']);
+	});
+
+	it('should extract the strings', () => {
+		const contents = `
+
+		export class AppModule {
+			constructor() {
+				MK('DYNAMIC_TRAD.val1');
+				MK('DYNAMIC_TRAD.val2');
+			}
+		}
+		`;
+		const keys = parser.extract(contents, componentFilename).keys();
+		expect(keys).to.deep.equal(['DYNAMIC_TRAD.val1', 'DYNAMIC_TRAD.val2']);
+	});
+
+});


### PR DESCRIPTION
Hey, i just forked to add back an old feature that was probably removed by design by biesbjerg when he introduced the ngx-extract-translate-marker package, that I was using in a work project.(-m or --marker option that allow you to use any function as marker very similar to marker from ngx-translate-extract-marker but less constraining, because you dont have to use the no-op marker function) 

Our use case is that we want to use a custom function that does something specific as the marker and not use the marker function from ngx-extract-translate-marker which is a no-op. Our use case is like this:
```ts
import { TR } from 'my/path/translate'
class Foo {
    public method() {
        this.member = TR('SOME.LOCALIZED.STRING', {param: this.someValue} )
    }
}
```
```json
{
    "i18n:extract": "ngx-translate-extract --fi=\"  \" --input ./src --output ./src/assets/i18n/fr.json --marker TR --clean --sort --format json -k"
}
```
basically `TR` here is just a function that wraps a bound instance of the translateService.instant method but it is global (no need to inject translateService in each components or service, just need to import it once per file) and you can pass it a second parameter for interpolation. (All of this is just for convenience and trying to lowering use and maintenance complexity a little)

At first i tried your new feature of matching any ngx-translate-extract-marker with the regex(great idea!)  by making my own module in my project and customizing the function but it did not work because of the way function calls are resolved:

```ts
	const query = `CallExpression:has(Identifier[name="${fnName}"]):not(:has(PropertyAccessExpression))`;
	return tsquery<CallExpression>(node, query);
```
because of the condition `:not(:has(PropertyAccessExpression))` my sample is rejected because of the property access in the second argument. I understand that it was probably designed to prevent method access with a method that would be called `marker`
but this selector was filtering some calls that i did not want it to on my project because of this condition.

Maybe we could remove this condition and add some logic in findFunctionCall like i did in this PR:


(in the foreach):
```ts
if (!isIdentifier(callExpression.expression) || callExpression.expression.escapedText != this.fnName) {
	return
}
  ```
  
  